### PR TITLE
style: apply glass theme to algorithm info

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>AlgoViz - Interactive Algorithm Visualizations</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/AlgorithmInfo.tsx
+++ b/src/components/AlgorithmInfo.tsx
@@ -431,26 +431,32 @@ const AlgorithmInfo = ({ algorithm }: AlgorithmInfoProps) => {
         {/* Right Column - Complexity */}
         <div className="space-y-4">
           {/* Time Complexity - Compact */}
-          <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100">
+          <div className="glass-card p-4">
             <div className="flex items-center gap-2 mb-3">
               <Clock className="text-orange-500" size={18} />
-              <h4 className="font-semibold text-gray-800">Time Complexity</h4>
+              <h4 className="font-semibold text-white">Time Complexity</h4>
             </div>
 
             <div className="space-y-3">
               <div className="flex justify-between items-center">
-                <span className="text-sm font-medium text-gray-700">Best:</span>
-                <div className="text-xs px-3 py-1.5 rounded-full text-white font-mono font-bold shadow-lg border border-gray-300" style={{
-                  background: getComplexityColor(details.bestCase)
-                }}>
+                <span className="text-sm font-medium text-gray-300">Best:</span>
+                <div
+                  className="text-xs px-3 py-1.5 rounded-full text-white font-mono font-bold shadow-lg border border-white/20"
+                  style={{
+                    background: getComplexityColor(details.bestCase)
+                  }}
+                >
                   {details.bestCase}
                 </div>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-sm font-medium text-gray-700">Worst:</span>
-                <div className="text-xs px-3 py-1.5 rounded-full text-white font-mono font-bold shadow-lg border border-gray-300" style={{
-                  background: getComplexityColor(details.worstCase)
-                }}>
+                <span className="text-sm font-medium text-gray-300">Worst:</span>
+                <div
+                  className="text-xs px-3 py-1.5 rounded-full text-white font-mono font-bold shadow-lg border border-white/20"
+                  style={{
+                    background: getComplexityColor(details.worstCase)
+                  }}
+                >
                   {details.worstCase}
                 </div>
               </div>
@@ -458,32 +464,35 @@ const AlgorithmInfo = ({ algorithm }: AlgorithmInfoProps) => {
           </div>
 
           {/* Space Complexity - Compact */}
-          <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100">
+          <div className="glass-card p-4">
             <div className="flex items-center gap-2 mb-3">
               <HardDrive className="text-green-500" size={18} />
-              <h4 className="font-semibold text-gray-800">Space Complexity</h4>
+              <h4 className="font-semibold text-white">Space Complexity</h4>
             </div>
 
             <div className="text-center">
-              <div className="text-lg px-4 py-2 rounded-full text-white font-mono font-bold inline-block shadow-lg border border-gray-300" style={{
-                background: getComplexityColor(details.spaceComplexity)
-              }}>
+              <div
+                className="text-lg px-4 py-2 rounded-full text-white font-mono font-bold inline-block shadow-lg border border-white/20"
+                style={{
+                  background: getComplexityColor(details.spaceComplexity)
+                }}
+              >
                 {details.spaceComplexity}
               </div>
             </div>
           </div>
 
           {/* Quick Stats */}
-          <div className="bg-gradient-to-br from-gray-50 to-gray-100 p-4 rounded-xl">
-            <h4 className="font-semibold text-gray-800 mb-2">Quick Stats</h4>
+          <div className="glass-card p-4">
+            <h4 className="font-semibold text-white mb-2">Quick Stats</h4>
             <div className="grid grid-cols-2 gap-2 text-xs">
-              <div className="text-center p-2 bg-white rounded-lg">
-                <div className="font-semibold text-gray-800">Category</div>
-                <div className="text-gray-600">{details.category}</div>
+              <div className="text-center p-2 glass-card">
+                <div className="font-semibold text-white">Category</div>
+                <div className="text-gray-300">{details.category}</div>
               </div>
-              <div className="text-center p-2 bg-white rounded-lg">
-                <div className="font-semibold text-gray-800">Difficulty</div>
-                <div className="text-gray-600">
+              <div className="text-center p-2 glass-card">
+                <div className="font-semibold text-white">Difficulty</div>
+                <div className="text-gray-300">
                   {getDifficulty(algorithm)}
                 </div>
               </div>
@@ -493,8 +502,8 @@ const AlgorithmInfo = ({ algorithm }: AlgorithmInfoProps) => {
       </div>
 
       {/* Color Legend - Adaptive based on category */}
-      <div className="mt-6 bg-gradient-to-r from-gray-50 to-blue-50 p-4 rounded-xl">
-        <h4 className="font-semibold text-gray-800 mb-3 text-center">Visualization Colors</h4>
+      <div className="mt-6 glass-card p-4">
+        <h4 className="font-semibold text-white mb-3 text-center">Visualization Colors</h4>
         <div className="flex justify-center gap-4 text-xs flex-wrap">
           {details.category === 'Sorting' && (
             <>


### PR DESCRIPTION
## Summary
- bring algorithm info cards into the glass/gradient theme for a consistent look
- tweak the HTML document title to reflect AlgoViz branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dff0acf8832d8219e7f61f25763d