### PR TITLE
feat: improve debug panel responsiveness

### DIFF
--- a/src/components/DebugInfo.tsx
+++ b/src/components/DebugInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import type { VisualizationState } from '../types';
 
 interface DebugInfoProps {
@@ -8,18 +8,31 @@ interface DebugInfoProps {
 
 const DebugInfo = ({ visualizationState, selectedCategory }: DebugInfoProps) => {
   const currentStep = visualizationState.steps[visualizationState.currentStep];
-  
+  const panelRef = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (panelRef.current) {
+        panelRef.current.open = window.innerWidth >= 768;
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   return (
-    <div className="glass-card p-4 mt-4 text-xs">
-      <h4 className="font-bold mb-2">Debug Info:</h4>
-      <div className="space-y-1">
-        <div>Category: {selectedCategory}</div>
-        <div>Total Steps: {visualizationState.steps.length}</div>
-        <div>Current Step: {visualizationState.currentStep + 1}</div>
-        <div>Is Playing: {visualizationState.isPlaying ? 'Yes' : 'No'}</div>
-        <div>Is Paused: {visualizationState.isPaused ? 'Yes' : 'No'}</div>
+    <details ref={panelRef} className="glass-card p-4 mt-4 text-xs font-mono">
+      <summary className="font-bold cursor-pointer select-none">Debug Info</summary>
+      <div className="mt-2 divide-y divide-white/10">
+        <div className="py-1">Category: {selectedCategory}</div>
+        <div className="py-1">Total Steps: {visualizationState.steps.length}</div>
+        <div className="py-1">Current Step: {visualizationState.currentStep + 1}</div>
+        <div className="py-1">Is Playing: {visualizationState.isPlaying ? 'Yes' : 'No'}</div>
+        <div className="py-1">Is Paused: {visualizationState.isPaused ? 'Yes' : 'No'}</div>
         {currentStep && (
-          <div className="mt-2">
+          <div className="py-1 space-y-1">
             <div className="font-semibold">Current Step Data:</div>
             <div>Message: {currentStep.message || 'No message'}</div>
             {selectedCategory === 'pathfinding' && (
@@ -34,7 +47,7 @@ const DebugInfo = ({ visualizationState, selectedCategory }: DebugInfoProps) => 
           </div>
         )}
       </div>
-    </div>
+    </details>
   );
 };
 


### PR DESCRIPTION
## Summary
- make DebugInfo collapsible using `<details>` and responsive to viewport size
- apply monospace font and subtle dividers within glass-card container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 19 problems (17 errors, 2 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a3eaf80acc832da37422dac6e20ae1