### PR TITLE
style: gradient algorithm cards

### DIFF
--- a/src/components/AlgorithmSelector.tsx
+++ b/src/components/AlgorithmSelector.tsx
@@ -8,12 +8,18 @@ interface AlgorithmSelectorProps {
 }
 
 const AlgorithmSelector = ({ selectedAlgorithm, onAlgorithmChange }: AlgorithmSelectorProps) => {
-  const algorithms: { value: SortingAlgorithm; label: string; icon: React.ReactNode; complexity: string }[] = [
-    { value: 'bubble', label: 'Bubble Sort', icon: <ArrowUpDown size={20} />, complexity: 'O(n²)' },
-    { value: 'quick', label: 'Quick Sort', icon: <Zap size={20} />, complexity: 'O(n log n)' },
-    { value: 'merge', label: 'Merge Sort', icon: <GitBranch size={20} />, complexity: 'O(n log n)' },
-    { value: 'heap', label: 'Heap Sort', icon: <BarChart3 size={20} />, complexity: 'O(n log n)' },
-    { value: 'insertion', label: 'Insertion Sort', icon: <TrendingUp size={20} />, complexity: 'O(n²)' },
+  const algorithms: {
+    value: SortingAlgorithm;
+    label: string;
+    icon: React.ReactNode;
+    complexity: string;
+    gradient: string;
+  }[] = [
+    { value: 'bubble', label: 'Bubble Sort', icon: <ArrowUpDown size={20} />, complexity: 'O(n²)', gradient: 'from-pink-500 to-rose-500' },
+    { value: 'quick', label: 'Quick Sort', icon: <Zap size={20} />, complexity: 'O(n log n)', gradient: 'from-yellow-500 to-orange-500' },
+    { value: 'merge', label: 'Merge Sort', icon: <GitBranch size={20} />, complexity: 'O(n log n)', gradient: 'from-green-500 to-emerald-500' },
+    { value: 'heap', label: 'Heap Sort', icon: <BarChart3 size={20} />, complexity: 'O(n log n)', gradient: 'from-blue-500 to-cyan-500' },
+    { value: 'insertion', label: 'Insertion Sort', icon: <TrendingUp size={20} />, complexity: 'O(n²)', gradient: 'from-purple-500 to-violet-500' },
   ];
 
   return (
@@ -29,23 +35,31 @@ const AlgorithmSelector = ({ selectedAlgorithm, onAlgorithmChange }: AlgorithmSe
             Sorting Algorithms
           </h2>
         </div>
-        <p className="text-xl text-gray-300 max-w-3xl mx-auto mb-8">
+        <p className="text-xl text-gray-400 max-w-3xl mx-auto mb-6">
           Explore various sorting algorithms and watch them in action
         </p>
-        
+
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-          {algorithms.map(({ value, label, icon, complexity }, index) => (
+          {algorithms.map(({ value, label, icon, complexity, gradient }, index) => (
             <motion.button
               key={value}
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
               onClick={() => onAlgorithmChange(value)}
-              className={`algorithm-card relative group ${selectedAlgorithm === value ? 'active' : ''}`}
+              className={`relative rounded-xl p-[1px] bg-gradient-to-br ${gradient} ${
+                selectedAlgorithm === value ? '' : 'opacity-60 hover:opacity-100'
+              }`}
             >
-              <div className="algo-icon">{icon}</div>
-              <div className="algo-title">{label}</div>
-              <div className="algo-meta">{complexity}</div>
+              <div className="glass-card !border-0 rounded-xl p-4 flex flex-col items-center gap-2">
+                <div className="w-10 h-10 rounded-lg flex items-center justify-center bg-white/10 text-white">
+                  {icon}
+                </div>
+                <div className="text-sm font-semibold text-white">{label}</div>
+                <div className="text-xs text-gray-400 px-2 py-0.5 rounded-full bg-white/5">
+                  {complexity}
+                </div>
+              </div>
             </motion.button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- restyle algorithm selector cards with glass-card base and per-algorithm gradient borders
- align icon, title, and complexity chip spacing for consistent layout
- use light gray secondary text to better match the dark theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected lint errors in unrelated files)*
- `npx eslint src/components/AlgorithmSelector.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a3eaf14dd4832dafbc07babeead3f2