### PR TITLE
style: improve visualizer card styling

### DIFF
--- a/src/components/GridVisualizer.tsx
+++ b/src/components/GridVisualizer.tsx
@@ -11,13 +11,22 @@ const GridVisualizer = ({ grid, onCellClick, isInteractive = false }: GridVisual
   console.log('GridVisualizer rendering with grid size:', grid?.length, 'x', grid?.[0]?.length);
   console.log('Sample cells:', grid?.slice(0, 2)?.map(row => row.slice(0, 3)));
 
+  const CELL_COLORS = {
+    start: 'bg-green-500',
+    end: 'bg-red-500',
+    path: 'bg-yellow-400',
+    wall: 'bg-gray-800',
+    visited: 'bg-blue-200',
+    default: 'bg-white'
+  } as const;
+
   const getCellColor = (cell: GridCell): string => {
-    if (cell.isStart) return 'bg-green-500';
-    if (cell.isEnd) return 'bg-red-500';
-    if (cell.isPath) return 'bg-yellow-400';
-    if (cell.isWall) return 'bg-gray-800';
-    if (cell.isVisited) return 'bg-blue-200';
-    return 'bg-white';
+    if (cell.isStart) return CELL_COLORS.start;
+    if (cell.isEnd) return CELL_COLORS.end;
+    if (cell.isPath) return CELL_COLORS.path;
+    if (cell.isWall) return CELL_COLORS.wall;
+    if (cell.isVisited) return CELL_COLORS.visited;
+    return CELL_COLORS.default;
   };
 
   const getCellBorder = (cell: GridCell): string => {
@@ -54,32 +63,35 @@ const GridVisualizer = ({ grid, onCellClick, isInteractive = false }: GridVisual
           </div>
         </div>
 
-        <div
-          className="grid-surface mb-6 select-none grid-board"
-          style={{ display: 'grid', gridTemplateColumns: `repeat(${grid[0]?.length || 0}, 1fr)` }}
-        >
-          {grid.map((row, y) =>
-            row.map((cell, x) => (
-              <motion.div
-                key={`${x}-${y}`}
-                initial={{ scale: 0.8, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                transition={{
-                  duration: 0.2,
-                  delay: (x + y) * 0.01,
-                  type: "spring",
-                  stiffness: 300
-                }}
-                className={`
-                  cell cursor-pointer transition-all duration-200 hover:scale-110
-                  ${getCellColor(cell)} ${getCellBorder(cell)}
-                  ${isInteractive ? 'hover:shadow-md' : ''}
-                `}
-                onClick={() => isInteractive && onCellClick?.({ x, y })}
-                title={`(${x}, ${y}) ${cell.isWall ? '- Wall' : ''} ${cell.distance !== Infinity ? `- Distance: ${cell.distance}` : ''}`}
-              />
-            ))
-          )}
+        <div className="canvas-card backdrop-blur-md grid-surface mb-6 select-none">
+          <div
+            className="grid-board mx-auto"
+            style={{ display: 'grid', gridTemplateColumns: `repeat(${grid[0]?.length || 0}, 1fr)` }}
+          >
+            {grid.map((row, y) =>
+              row.map((cell, x) => (
+                <motion.div
+                  key={`${x}-${y}`}
+                  initial={{ scale: 0.8, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  whileHover={isInteractive ? { scale: 1.05, y: -2 } : undefined}
+                  transition={{
+                    duration: 0.2,
+                    delay: (x + y) * 0.01,
+                    type: "spring",
+                    stiffness: 300
+                  }}
+                  className={`
+                    cell ${isInteractive ? 'cursor-pointer' : ''} transition-all duration-200
+                    ${getCellColor(cell)} ${getCellBorder(cell)}
+                    ${isInteractive ? 'hover:shadow-md' : ''}
+                  `}
+                  onClick={() => isInteractive && onCellClick?.({ x, y })}
+                  title={`(${x}, ${y}) ${cell.isWall ? '- Wall' : ''} ${cell.distance !== Infinity ? `- Distance: ${cell.distance}` : ''}`}
+                />
+              ))
+            )}
+          </div>
         </div>
 
         {isInteractive && (

--- a/src/components/TreeVisualizer.tsx
+++ b/src/components/TreeVisualizer.tsx
@@ -95,14 +95,19 @@ const TreeVisualizer = ({ tree, highlightedNodes = [] }: TreeVisualizerProps) =>
 
   console.log('Rendering tree with nodes:', nodes.length, 'edges:', edges.length);
 
+  const NODE_COLORS = {
+    normal: 'bg-gradient-to-r from-blue-500 to-purple-600',
+    highlight: 'bg-gradient-to-r from-yellow-400 to-orange-500'
+  } as const;
+
   return (
     <div className="glass-card p-6">
       <div className="mb-4 text-center">
         <h3 className="text-xl font-bold mb-2">Binary Search Tree</h3>
         <p className="text-sm opacity-80">Nodes: {nodes.length} | Highlighted: {highlightedNodes.length}</p>
       </div>
-      
-      <div className="relative tree-surface overflow-hidden" style={{ height: '500px', width: '800px' }}>
+
+      <div className="canvas-card backdrop-blur-md tree-surface overflow-hidden mx-auto w-full max-w-[800px]" style={{ height: '500px' }}>
         {/* SVG for edges */}
         <svg width="100%" height="100%" className="absolute inset-0" style={{ zIndex: 1 }}>
           {edges.map((edge, index) => (
@@ -125,17 +130,18 @@ const TreeVisualizer = ({ tree, highlightedNodes = [] }: TreeVisualizerProps) =>
         {/* Nodes */}
         {nodes.map((node, index) => {
           const isHighlighted = highlightedNodes.includes(parseInt(node.id)) || highlightedNodes.includes(node.id as any);
-          
+
           return (
             <motion.div
               key={`node-${node.id}`}
               initial={{ scale: 0, opacity: 0 }}
-              animate={{ 
-                scale: isHighlighted ? 1.3 : 1, 
-                opacity: 1 
+              animate={{
+                scale: isHighlighted ? 1.3 : 1,
+                opacity: 1
               }}
-              transition={{ 
-                duration: 0.5, 
+              whileHover={{ scale: 1.05, y: -2 }}
+              transition={{
+                duration: 0.5,
                 delay: index * 0.1,
                 type: "spring",
                 stiffness: 200
@@ -146,6 +152,9 @@ const TreeVisualizer = ({ tree, highlightedNodes = [] }: TreeVisualizerProps) =>
                 left: node.x - 25,
                 top: node.y - 25,
                 zIndex: 2,
+                background: isHighlighted
+                  ? 'linear-gradient(to right, #facc15, #fb923c)'
+                  : 'linear-gradient(to right, #3b82f6, #8b5cf6)'
               }}
             >
               {node.value}
@@ -157,11 +166,11 @@ const TreeVisualizer = ({ tree, highlightedNodes = [] }: TreeVisualizerProps) =>
       <div className="mt-6 glass-card p-4">
         <div className="flex justify-center gap-8 text-sm">
           <div className="flex items-center gap-2">
-            <div className="w-5 h-5 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full"></div>
+            <div className={`w-5 h-5 ${NODE_COLORS.normal} rounded-full`}></div>
             <span className="font-medium">Normal Node</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-5 h-5 bg-gradient-to-r from-yellow-400 to-orange-500 rounded-full"></div>
+            <div className={`w-5 h-5 ${NODE_COLORS.highlight} rounded-full`}></div>
             <span className="font-medium">Active/Highlighted</span>
           </div>
         </div>

--- a/src/components/Visualizer.tsx
+++ b/src/components/Visualizer.tsx
@@ -147,7 +147,7 @@ const Visualizer = ({ array, visualizationState }: VisualizerProps) => {
           className="glass-card p-8 max-w-6xl mx-auto"
         >
           {/* Visualization Header */}
-          <div className="viz-toolbar">
+          <div className="viz-toolbar glass-card backdrop-blur-md">
             <div className="flex items-center gap-3">
               <BarChart3 size={22} className="text-purple-600" />
               <h2 className="text-2xl font-extrabold text-gray-800">Live Visualization</h2>
@@ -158,7 +158,7 @@ const Visualizer = ({ array, visualizationState }: VisualizerProps) => {
           {/* Canvas Container */}
           <div className="relative mb-8">
             <div className="absolute inset-0 bg-gradient-to-r from-blue-500/5 via-purple-500/5 to-pink-500/5 rounded-2xl blur-xl" />
-            <div className="canvas-container relative">
+            <div className="canvas-card backdrop-blur-md canvas-container relative mx-auto w-full max-w-[1000px]">
               <canvas
                 ref={canvasRef}
                 width={1000}


### PR DESCRIPTION
## Summary
- add canvas-card and glass-card wrappers with backdrop blur
- unify grid and tree colors with hover transitions
- center canvases for responsive sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eaf50bc0832d9568dc3d2f2dde28