### PR TITLE
Improve search input and visualize color legend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ function Controls({
         <div className="button-row flex flex-wrap justify-center gap-4">
           {(selectedCategory === 'searching' || selectedCategory === 'trees') && (
             <div className="flex items-center gap-2 bg-white/10 p-3 rounded-lg shadow-inner">
-              <label htmlFor="target" className="text-gray-300 font-semibold">
+              <label htmlFor="target" className="text-gray-200 font-semibold">
                 {selectedCategory === 'searching' ? 'Search for:' : 'Value:'}
               </label>
               <input
@@ -84,7 +84,7 @@ function Controls({
                 value={searchTarget}
                 onChange={(e) => onSearchTargetChange(parseInt(e.target.value) || 0)}
                 disabled={isDisabled}
-                className="w-20 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-24 px-3 py-2 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
           )}

--- a/src/components/AlgorithmInfo.tsx
+++ b/src/components/AlgorithmInfo.tsx
@@ -508,80 +508,84 @@ const AlgorithmInfo = ({ algorithm }: AlgorithmInfoProps) => {
       {/* Color Legend - Adaptive based on category */}
       <div className="mt-6 glass-card p-4">
         <h4 className="font-semibold text-white mb-3 text-center">Visualization Colors</h4>
-        <div className="flex justify-center gap-4 text-xs flex-wrap">
-          {details.category === 'Sorting' && (
-            <>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#667eea' }}></div>
-                <span>Default</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#f59e0b' }}></div>
-                <span>Comparing</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#ef4444' }}></div>
-                <span>Swapping</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#10b981' }}></div>
-                <span>Sorted</span>
-              </div>
-            </>
-          )}
-          {details.category === 'Pathfinding' && (
-            <>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#10b981' }}></div>
-                <span>Start</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#ef4444' }}></div>
-                <span>End</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#1f2937' }}></div>
-                <span>Wall</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#93c5fd' }}></div>
-                <span>Visited</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#fbbf24' }}></div>
-                <span>Path</span>
-              </div>
-            </>
-          )}
-          {details.category === 'Searching' && (
-            <>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#667eea' }}></div>
-                <span>Default</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#f59e0b' }}></div>
-                <span>Checking</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#10b981' }}></div>
-                <span>Found</span>
-              </div>
-            </>
-          )}
-          {details.category === 'Trees' && (
-            <>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#667eea' }}></div>
-                <span>Normal</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#f59e0b' }}></div>
-                <span>Highlighted</span>
-              </div>
-            </>
-          )}
-        </div>
+        {['Sorting', 'Pathfinding', 'Searching', 'Trees'].includes(details.category) ? (
+          <div className="flex justify-center gap-4 text-xs flex-wrap text-gray-200">
+            {details.category === 'Sorting' && (
+              <>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#667eea' }}></div>
+                  <span>Default</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#f59e0b' }}></div>
+                  <span>Comparing</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#ef4444' }}></div>
+                  <span>Swapping</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#10b981' }}></div>
+                  <span>Sorted</span>
+                </div>
+              </>
+            )}
+            {details.category === 'Pathfinding' && (
+              <>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#10b981' }}></div>
+                  <span>Start</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#ef4444' }}></div>
+                  <span>End</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#1f2937' }}></div>
+                  <span>Wall</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#93c5fd' }}></div>
+                  <span>Visited</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#fbbf24' }}></div>
+                  <span>Path</span>
+                </div>
+              </>
+            )}
+            {details.category === 'Searching' && (
+              <>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#667eea' }}></div>
+                  <span>Default</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#f59e0b' }}></div>
+                  <span>Checking</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#10b981' }}></div>
+                  <span>Found</span>
+                </div>
+              </>
+            )}
+            {details.category === 'Trees' && (
+              <>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#667eea' }}></div>
+                  <span>Normal</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-3 h-3 rounded" style={{ backgroundColor: '#f59e0b' }}></div>
+                  <span>Highlighted</span>
+                </div>
+              </>
+            )}
+          </div>
+        ) : (
+          <p className="text-center text-gray-200 text-sm">No color information available.</p>
+        )}
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- Style the search input with darker text and a visible background for better readability
- Enhance visualization color legend with clearer text color and fallback messaging when no legend is available

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a47cbdf204832da83363ad5e002328